### PR TITLE
Add clear function

### DIFF
--- a/lib/mask_text_input_formatter.dart
+++ b/lib/mask_text_input_formatter.dart
@@ -31,8 +31,7 @@ class MaskTextInputFormatter extends TextInputFormatter {
     }
     _calcMaskLength();
     final String unmaskedText = getUnmaskedText();
-    _resultTextArray.clear();
-    _resultTextMasked = "";
+    clear();
     return _formatUpdate(TextEditingValue(), TextEditingValue(text: unmaskedText, selection: TextSelection(baseOffset: unmaskedText.length, extentOffset: unmaskedText.length)));
   }
 
@@ -66,6 +65,7 @@ class MaskTextInputFormatter extends TextInputFormatter {
   
   /// Clear the text stored in the formatter
   void clear() {
+    _resultTextMasked = "";
     _resultTextArray.clear();
   }
 

--- a/test/mask_text_input_formatter_test.dart
+++ b/test/mask_text_input_formatter_test.dart
@@ -158,4 +158,13 @@ void main() {
     maskTextInputFormatter.formatEditUpdate(TextEditingValue(), TextEditingValue(text: "+1 (234) 567-89-01", selection: TextSelection.collapsed(offset: 12)));
     expect(maskTextInputFormatter.getMaskedText(), "+1 (234) 567-89-01");
   });
+  
+  test('Clear text', () {
+    final maskTextInputFormatter = MaskTextInputFormatter(mask: "+1 (###) ###-##-##");
+    maskTextInputFormatter.formatEditUpdate(TextEditingValue(), TextEditingValue(text: "+1 (234) 567-89-01", selection: TextSelection.collapsed(offset: 12)));
+    maskTextInputFormatter.clear();
+    expect(maskTextInputFormatter.isFill(), false);
+    expect(maskTextInputFormatter.getMaskedText(), "");
+    expect(maskTextInputFormatter.getUnmaskedText(), "");
+  });
 }


### PR DESCRIPTION
This adds functionality to clear the formatter as clearing the TextEditingController of the TextField or TextFormField that are using this formatter will yield strange behavior without also clearing the cached text of the formatter.