### PR TITLE
Fixing out of bounds exception

### DIFF
--- a/lib/mask_text_input_formatter.dart
+++ b/lib/mask_text_input_formatter.dart
@@ -88,7 +88,7 @@ class MaskTextInputFormatter extends TextInputFormatter {
     int currentTotalText = _resultTextArray.length;
     int selectionStart = 0;
     int selectionLength = 0;
-    for (var i = 0; i < replaceStart + replaceLength; i++) {
+    for (var i = 0; i < min(replaceStart + replaceLength, _mask.length); i++) {
       if (_maskChars.contains(_mask[i]) && currentTotalText > 0) {
         currentTotalText -= 1;
         if (i < replaceStart) {


### PR DESCRIPTION
I've had a few instances where "replaceStart + replaceLength" would be larger than the _mask.length in the first for loop when i was trying to delete a char of the string, causing and out of bounds excetion in line 92. This change fixed it.