### PR TITLE
Added support for eager autocompletion

### DIFF
--- a/test/mask_text_input_formatter_test.dart
+++ b/test/mask_text_input_formatter_test.dart
@@ -240,6 +240,27 @@ void main() {
       expect(maskTextInputFormatter.getMaskedText(), "");
     });
 
+    test('Eager autocompletion', () {
+      const String input = '1';
+      const String mask = '#/#';
+      final maskTextInputFormatter = MaskTextInputFormatter(mask: mask, autoCompletion: MaskAutoCompletion.eager);
+      expect(mask, maskTextInputFormatter.getMask());
+      final masked = maskTextInputFormatter.maskText(input);
+      expect(masked, '1/');
+      final unmasked = maskTextInputFormatter.unmaskText(masked);
+      expect(unmasked, input);
+    });
+
+    test('Lazy autocompletion', () {
+      const String input = '1';
+      const String mask = '#/#';
+      final maskTextInputFormatter = MaskTextInputFormatter(mask: mask, autoCompletion: MaskAutoCompletion.lazy);
+      expect(mask, maskTextInputFormatter.getMask());
+      final masked = maskTextInputFormatter.maskText(input);
+      expect(masked, '1');
+      final unmasked = maskTextInputFormatter.unmaskText(masked);
+      expect(unmasked, input);
+    });
   });
 
 }


### PR DESCRIPTION
Added a parameter `autoCompletion` in the `MaskTextInputFormatter` with two values:
 - `MaskAutoCompletion.lazy`: the current behaviour, where unfiltered characters are added once the following filtered character is input.
Ex: with the mask "#/#", "1" then "2" output "1" then "1/2"
 - `MaskAutoCompletion.eager`: the new behaviour, where unfiltered characters are added when the previous filtered character is input. 
Ex: with the mask "#/#", "1" then "2" output "1/" then "1/2"

This fixes #44 