### PR TITLE
fix bug in updateMask call from formatEditUpdate

### DIFF
--- a/lib/mask_text_input_formatter.dart
+++ b/lib/mask_text_input_formatter.dart
@@ -42,7 +42,7 @@ class MaskTextInputFormatter implements TextInputFormatter {
   }
 
   /// Change the mask
-  TextEditingValue updateMask({ String? mask, Map<String, RegExp>? filter}) {
+  TextEditingValue updateMask({ String? mask, Map<String, RegExp>? filter, TextEditingValue? newValue}) {
     _mask = mask;
     if (filter != null) {
       _updateFilter(filter);
@@ -50,7 +50,7 @@ class MaskTextInputFormatter implements TextInputFormatter {
     _calcMaskLength();
     final unmaskedText = getUnmaskedText();
     clear();
-    return formatEditUpdate(TextEditingValue.empty, TextEditingValue(text: unmaskedText, selection: TextSelection.collapsed(offset: unmaskedText.length)));
+    return formatEditUpdate(TextEditingValue.empty, newValue ?? TextEditingValue(text: unmaskedText, selection: TextSelection.collapsed(offset: unmaskedText.length)));
   }
 
   /// Get current mask


### PR DESCRIPTION
I experienced a problem calling updateMask inside an @overide of formatEditUpdate in order to make a custom mask.
When calling updateMask with a pattern change, going from 123.456 to 12.34.56.7, updateMask made a call to formatEditUpdate and passed newValue with an outdated value.
In this way, the attempt to change the mask was reversed, causing several bugs when typing the input. Not working as expected, or even preventing typing.

The change made in this PR makes it possible for the newValue informed inside the updateMask to be modified, in cases like mine, when the updateMask is called from within a formatEditUpdate. 
This change allows formatEditUpdate to receive an updated value when called by updateMask.